### PR TITLE
ci: bump actions/checkout version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18.12.1


### PR DESCRIPTION
Closes https://github.com/ScopeLift/railgun-shielder/issues/28 ~~(I think, let's see once CI runs)~~ seems to have worked